### PR TITLE
mkdir_p for images that don't have /tmp/chef-file-cache

### DIFF
--- a/lib/toft/chef/chef_runner.rb
+++ b/lib/toft/chef/chef_runner.rb
@@ -50,6 +50,7 @@ module Toft
       end
 
       def generate_solo_rb
+        mkdir_p "#{@root_dir}/tmp/chef-file-cache"
         solo = <<-EOF
 file_cache_path "/tmp/chef-file-cache"
 cookbook_path ["#{DEST_COOKBOOK_PATH}"]


### PR DESCRIPTION
The natty image didn't have the directory and caused an error if it wasn't created.  This automatically creates it.
