### PR TITLE
use @ip instead of fqdn to check if host is reachable

### DIFF
--- a/lib/toft/node.rb
+++ b/lib/toft/node.rb
@@ -168,7 +168,7 @@ CQWv13UgQjiHgQILXSb7xdzpWK1wpDoqIEWQugRyPQDeZhPWVbB4Lg==
     def wait_remote_host_reachable
       wait_for do
         begin
-          return if Ping.pingecho fqdn, 0.1
+          return if Ping.pingecho @ip, 0.1
         rescue Exception
           # fix the strange pingcho exception
         end
@@ -180,6 +180,7 @@ CQWv13UgQjiHgQILXSb7xdzpWK1wpDoqIEWQugRyPQDeZhPWVbB4Lg==
       return if !block_given?
       max_try = TIMEOUT_IN_SECONDS / TRY_INTERVAL
       try = 0
+      
       while try < max_try
         output_progress
         yield


### PR DESCRIPTION
for some weird reason bind9 returns bogus results for n1.foo

root@hiroko:/usr/lib/ruby/gems/1.8/gems/toft-0.0.6# dig n1.foo                                                                                         

; <<>> DiG 9.7.3 <<>> n1.foo
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 1776
;; flags: qr; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0

;; QUESTION SECTION:
;n1.foo.                                IN      A

;; ANSWER SECTION:
n1.foo.                 0       IN      A       212.48.8.140

;; Query time: 1 msec
;; SERVER: 192.168.2.1#53(192.168.2.1)
;; WHEN: Sat Apr 28 08:37:12 2012
;; MSG SIZE  rcvd: 40

this is a workaround
