### PR TITLE
lxc-netstat --name is not working on ubuntu 10.04

### DIFF
--- a/lib/toft/node.rb
+++ b/lib/toft/node.rb
@@ -160,7 +160,7 @@ CQWv13UgQjiHgQILXSb7xdzpWK1wpDoqIEWQugRyPQDeZhPWVbB4Lg==
     
     def wait_sshd_running
       wait_for do
-        netstat = cmd("lxc-netstat --name #{@hostname} -ta")        
+        netstat = cmd("lxc-netstat -n #{@hostname} -ta")        
         return if netstat =~ /ssh/
       end
     end


### PR DESCRIPTION
But lxc-nestat -n is working ;)
