### PR TITLE
Fixes #11: Removes explicit apparmor conflict definition when creating .deb package

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,1 +1,0 @@
-rvm use 1.8.7-p352@toft

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    toft (0.0.12)
+    toft (0.0.13)
       net-ssh
 
 GEM

--- a/Rakefile
+++ b/Rakefile
@@ -49,8 +49,6 @@ eos
     -d bind9 \
     -d ntp \
     --replaces lxc \
-    --conflicts apparmor \
-    --conflicts apparmor-utils \
     --post-install "#{PROJECT_ROOT}/pkg/toft-lxc-post-install.sh" \
     .
     EOF


### PR DESCRIPTION
- Gemfile.lock update to toft (0.0.13)
- Removed --conflict arguments in package_deb task in Rakefile
